### PR TITLE
fix: use get request for account callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ class Autopilot {
 
 		this.account = {
 			get: (callback) => {
-				return this.handle(api.delete(`account`), callback);
+				return this.handle(api.get(`account`), callback);
 			}
 		};
 	}


### PR DESCRIPTION
Currently, the account request fails with error code: 405, saying delete method is not allowed. Skimmed through the code and found that we are trying to use delete callback, so this PR tries to just do a get request. 